### PR TITLE
[feature/example-remove-docs-tab] storybook docs tab 비활성화

### DIFF
--- a/src/stories/Example.stories.js
+++ b/src/stories/Example.stories.js
@@ -3,6 +3,11 @@ import Template from "./Template";
 export default {
   title: "Example/UserAgent",
   component: Template,
+  parameters: {
+    previewTabs: {
+      "storybook/docs/panel": { hidden: true },
+    },
+  },
 };
 
 export const IOS = {


### PR DESCRIPTION
- docs에서 스토리 별로 iframe를 처리하고 있지 않아, 제대로 표시되지 않습니다.
- 그에 따라 docs 탭을 제거했습니다.