### PR TITLE
[feature/canary-bug-fix] 카나리 버전 지원

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,7 @@
+{
+  "canary": {
+    "target": "pr-body",
+    "message": "Install PR version: `yarn add -D my-project@%v`",
+    "force": true
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies


### PR DESCRIPTION
- 카나리가 생성안되는 버그 수정
- actions node 18로 변경

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>Install PR version: `yarn add -D my-project@<code>6.4.1--canary.28.5979194539.0</code>`</summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-useragent@6.4.1--canary.28.5979194539.0
  # or 
  yarn add storybook-addon-useragent@6.4.1--canary.28.5979194539.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
