### PR TITLE
[feature/only-story-mode] story 모드에서만 동작하도록 변경

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,7 +1,7 @@
 {
   "canary": {
     "target": "pr-body",
-    "message": "Install PR version: `yarn add -D my-project@%v`",
+    "message": "Install PR version: `npm install -D storybook-addon-useragent@%v`",
     "force": true
   }
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,6 +15,9 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
+  core: {
+    disableTelemetry: true, // 👈 Disables telemetry
+  },
   docs: {
     autodocs: "tag",
   },

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -9,7 +9,7 @@ addons.register(ADDON_ID, () => {
     type: types.TOOL,
     title: TOOL_TITLE,
     paramKey: PARAM_KEY,
-    match: ({ viewMode }) => !!viewMode?.match(/^(story|docs)$/),
+    match: ({ viewMode }) => viewMode === "story",
     render: Tool,
   });
 });


### PR DESCRIPTION
- story 모드에서만 동작하도록 변경했습니다.
-  telemetry 비활성화처리 했습니다.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>Install PR version: `yarn add -D my-project@<code>6.4.1--canary.30.5979326123.0</code>`</summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-useragent@6.4.1--canary.30.5979326123.0
  # or 
  yarn add storybook-addon-useragent@6.4.1--canary.30.5979326123.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
